### PR TITLE
Improved Phonology Generation Realism

### DIFF
--- a/selphone/constraints/constraintCriteria/placeCriteria.py
+++ b/selphone/constraints/constraintCriteria/placeCriteria.py
@@ -10,7 +10,8 @@ corresponding places.
 # Determines which places to add to the constraints
 def placeCriteria(curr_num_places: int, sel_phonemes: list[list]) -> list[int]:
     places = Counter(map(lambda sel_phoneme: sel_phoneme[1] % 32, sel_phonemes))
-    
+    manners = Counter(map(lambda sel_phoneme: (sel_phoneme[1] & (7 << 8)) % 2048, sel_phonemes))
+
     match curr_num_places:
         case 2: # Add velar, glottal, and both labial places
             return [12, 4, 9, 0]
@@ -19,8 +20,13 @@ def placeCriteria(curr_num_places: int, sel_phonemes: list[list]) -> list[int]:
             if places[12] + places[4] + places[9] + places[0] >= 3:
                 return [18, 19]
         
-        case 8: # Add retroflex, uvular, and pharyngeal places
+        case 8: # Add retroflex and uvular places
             if places[18] or places[19]:
-                return [2, 17, 25]
+                return [2, 17]
+        
+        # RIGHT NOW WHEN A PALATAL OR POST-ALVEOLAR CONSONANT OCCURS, THE OTHER PLACE IS PURGED FROM CONSTRAINTS, LEAVING 9 PLACES
+        # IF DECIDE TO INCORPORATE CONSTRAINT EXCEPTIONS INTO CONSTRAINT LIMITS, CHANGE CASE BELOW TO 10
+        case 9 if manners[1024] + manners[1536] > 8: # Add pharyngeal place
+            return [25]
         
     return []

--- a/selphone/constraints/constraintExceptions.py
+++ b/selphone/constraints/constraintExceptions.py
@@ -35,7 +35,7 @@ def manageExceptions(place: int, manner: int, curr_permit: dict[int, dict[int, l
     # Dental and alveolar consonants of the same manner should not co-occur (for the purposes of this model)
     if place % 16 == 10:
         opp_place = place ^ 16 # Dental and alveolar places are differentiated by their 5th bit
-        if manner in curr_permit[opp_place] and num_phonemes < 37:
+        if manner in curr_permit[opp_place] and num_phonemes < max(37, num_phonemes * 2 // 3):
             del curr_permit[opp_place][manner]
 
         # Allow initial possibility of sibilant fricatives, taps, trills, and approximants in alveolar place (all are currently added at once so check only needs to look for one)

--- a/selphone/constraints/constraintLimits.py
+++ b/selphone/constraints/constraintLimits.py
@@ -30,15 +30,18 @@ def removeSelected(curr_permit: dict[int, dict[int, list[int]]], sel_phonemes: l
             manner = phoneme_bin & (7 << 8)
             laryng = phoneme_bin & (7 << 5)
 
-            laryngs = new_permit[place][manner]
-            spot = laryngs.index(laryng)
-            laryngs.pop(spot)
+            # THERE'S SOME REALLY RARE EDGE CASE WHERE NEW_PERMIT[PLACE] DOESN'T CONTAIN MANNER
+            # PROBABLY SHOULD LOOK INTO IT
+            if place in new_permit and manner in new_permit[place]:
+                laryngs = new_permit[place][manner]
+                spot = laryngs.index(laryng)
+                laryngs.pop(spot)
 
-            if len(laryngs) == 0:
-                del new_permit[place][manner]
+                if len(laryngs) == 0:
+                    del new_permit[place][manner]
 
-                if len(new_permit[place].keys()) == 0:
-                    del new_permit[place]
+                    if len(new_permit[place].keys()) == 0:
+                        del new_permit[place]
 
     return new_permit
 

--- a/selphone/constraints/phonemeConstraints.py
+++ b/selphone/constraints/phonemeConstraints.py
@@ -30,10 +30,15 @@ def updateConstraints(phoneme_bin: int, curr_permit: dict[int, dict[int, list]],
 
     if len(places) > 0:
         for new_place in places:
-            if new_place != 18:
+
+            if new_place not in [18, 25]:
                 curr_permit[new_place] = {0: [0]}
-            else:
+
+            elif new_place == 18: # Post-alveolars should start with affricates
                 curr_permit[new_place] = {512: [0]}
+
+            else: # Uvulars should start with fricatives
+                curr_permit[new_place] = {1024: [0]}
 
     # Update Manner Permissions
     manner = (phoneme_bin & (7 << 8)) % 2048

--- a/selphone/featureSelector.py
+++ b/selphone/featureSelector.py
@@ -2,20 +2,14 @@ import random
 from collections import Counter
 
 # Selects the place, manner, or laryngeal features for a phoneme.
-def selectFeature(feat: int, probs: dict[str, list[list]], guarantees: dict[str, Counter], sp_len: int, num_phonemes: int, loop_count: int, curr_permit) -> int:
+def selectFeature(feat: int, probs: dict[str, list[list]], loop_count: int, curr_permit) -> int:
     pfs = ["Place", "Manner", "Laryngeals"]
-    gfs = ["places", "manners", "laryngeals"]
 
     features = probs[pfs[feat]] + []
 
     features = list(filter(lambda cat: cat[0] in curr_permit, features))
     if len(features) == 0:
         return -1
-    
-    if guarantees[gfs[feat]].total() + sp_len == num_phonemes:
-        temp = list(filter(lambda cat: guarantees[gfs[feat]][cat[0]] > 0, features))
-        if len(temp) > 0:
-            features = temp
 
     features.sort(reverse=True, key=lambda cat: cat[1])
 
@@ -25,8 +19,6 @@ def selectFeature(feat: int, probs: dict[str, list[list]], guarantees: dict[str,
 
     # Lower selected prob and increase others
     prob_adjust = [0.001, 0.005, 0.05][feat]
-    # if feat == 2:
-    #     prob_adjust = 0.05
 
     for feature in probs[pfs[feat]]:
         if feature[0] == sel_feature:
@@ -39,13 +31,5 @@ def selectFeature(feat: int, probs: dict[str, list[list]], guarantees: dict[str,
         # If loop count is too high, the top two features might be in a positive feedback loop
         if loop_count > 100 and feature in features[:2]:
             feature[1] = 0
-
-    # Set place guarantees
-    if guarantees[gfs[feat]][sel_feature] > 0:
-        guarantees[gfs[feat]][sel_feature] -= 1
-
-    else:
-        if feat or sel_feature != 0: # Not glottal
-            guarantees[gfs[feat]][sel_feature] = min(2, num_phonemes - sp_len - guarantees[gfs[feat]].total() - 1)
 
     return sel_feature

--- a/selphone/featureSelector.py
+++ b/selphone/featureSelector.py
@@ -24,9 +24,9 @@ def selectFeature(feat: int, probs: dict[str, list[list]], guarantees: dict[str,
         sel_feature = random.choice(features[:2])[0]
 
     # Lower selected prob and increase others
-    prob_adjust = 0.005
-    if feat == 2:
-        prob_adjust = 0.05
+    prob_adjust = [0.001, 0.005, 0.05][feat]
+    # if feat == 2:
+    #     prob_adjust = 0.05
 
     for feature in probs[pfs[feat]]:
         if feature[0] == sel_feature:

--- a/selphone/guarantees.py
+++ b/selphone/guarantees.py
@@ -1,5 +1,34 @@
 from typing import Generator
 
+# Retroactively find consonants that would have triggered guarantees
+# and apply them in the context of the current phoneme
+def applyRetroGuarantees(curr_place: int, curr_manner: int, curr_laryng: int, curr_lat: int, sel_phonemes: list[tuple]):
+    for phoneme in sel_phonemes:
+        
+        # Laryngeal and nasalization guarantees
+        supr = phoneme[1] & (1 << 11) + phoneme[1] & (7 << 13)
+        if supr < (1 << 12):
+
+            manner = phoneme[1] & (7 << 8)
+            if manner == curr_manner:
+
+                place = phoneme[1] & 31
+                laryng = phoneme[1] & (7 << 5)
+                if not (place == curr_place or laryng == curr_laryng):
+
+                    yield curr_place + laryng + curr_manner + curr_lat + supr
+
+        # Other suprasegmental guarantees
+        else:
+            place = phoneme[1] & 31
+            if place == curr_place:
+
+                manner = phoneme[1] & (7 << 8)
+                laryng = phoneme[1] & (7 << 5)
+
+                if not (manner == curr_manner and laryng == curr_laryng):
+                    yield curr_place + curr_laryng + curr_manner + curr_lat + supr
+
 
 # Selects potential candidates for place and manner of guaranteed
 def pickCandidates(curr_place: int, curr_manner: int, curr_laryng: int, curr_supr: int, sel_phonemes: list[tuple]) -> Generator:
@@ -12,7 +41,9 @@ def pickCandidates(curr_place: int, curr_manner: int, curr_laryng: int, curr_sup
 
                 place = phoneme[1] & 31
                 if place != curr_place:
-                    yield place + curr_laryng + manner + curr_supr
+
+                    lat = phoneme[1] & (1 << 12)
+                    yield place + curr_laryng + manner + lat + curr_supr
 
         # Other suprasegmental guarantees
         else:
@@ -22,8 +53,9 @@ def pickCandidates(curr_place: int, curr_manner: int, curr_laryng: int, curr_sup
                 manner = phoneme[1] & (7 << 8)
                 laryng = phoneme[1] & (7 << 5)
 
-                if not (manner == curr_manner and laryng == curr_laryng):    
-                    yield place + laryng + manner + curr_supr
+                if not (manner == curr_manner and laryng == curr_laryng):
+                    lat = phoneme[1] & (1 << 12)
+                    yield place + laryng + manner + lat + curr_supr
 
                 
 """
@@ -38,22 +70,25 @@ other suprasegmentals guarantees will apply to phonemes of the same place
 and different manners instead.
 """
 def manageGuarantees(sel_phonemes: list[tuple]) -> list:
+    candidates = []
     curr_phoneme = sel_phonemes[-1][1]
 
     # Check if guarantees are applicable
-    curr_laryng = curr_phoneme & (7 << 5)
-    curr_nasal = curr_phoneme & (1 << 11)
-    curr_suprs = curr_phoneme & (7 << 13)
-
-    if not (curr_laryng or curr_nasal or curr_suprs):
-        return []
-    
     curr_place = curr_phoneme % 32
     curr_manner = curr_phoneme & (7 << 8)
-    candidates = []
+    curr_laryng = curr_phoneme & (7 << 5)
+    curr_nasal = curr_phoneme & (1 << 11)
+    curr_lat = curr_phoneme & (1 << 12)
+    curr_suprs = curr_phoneme & (7 << 13)
+    curr_son = curr_phoneme & (1 << 8)
 
-    if curr_laryng: # Laryngeal Feature Guarantees
-        candidates = list(set(pickCandidates(curr_place, curr_manner, curr_laryng, 0, sel_phonemes)))
+    candidates = list(set(applyRetroGuarantees(curr_place, curr_manner, curr_laryng, curr_lat, sel_phonemes)))
+
+    if ((curr_laryng == 128 and curr_son) or not (curr_laryng or curr_son)) and not (curr_nasal or curr_suprs):
+        return candidates
+
+    if curr_laryng or curr_son: # Laryngeal Feature Guarantees
+        candidates += list(set(pickCandidates(curr_place, curr_manner, curr_laryng, 0, sel_phonemes)))
 
     if curr_nasal: # Nasalization Guarantees
         candidates += list(set(pickCandidates(curr_place, curr_manner, curr_laryng, curr_nasal, sel_phonemes)))
@@ -83,4 +118,13 @@ if __name__ == "__main__":
     print(manageGuarantees(sps))
 
     sps = [('p', 12), ('t', 10), ('k', 9), ('s', 1546), ('d', 138), ('ⁿt', 2058), ('dʲ', 24714)]
+    print(manageGuarantees(sps))
+
+    sps = [('p', 12), ('t', 10), ('k', 9), ('s', 1546), ('d', 138), ('ⁿt', 2058), ('l', 6026), ('dʲ', 24714)]
+    print(manageGuarantees(sps))
+
+    sps = [('p', 12), ('t', 10), ('m', 393), ('n', 394), ('n̥', 266)]
+    print(manageGuarantees(sps))
+
+    sps = [('p', 12), ('t', 10), ('k', 9), ('s', 1546), ('d', 138), ('ⁿt', 2058), ('l', 6026), ('dʲ', 24714), ('ʈ', 2)]
     print(manageGuarantees(sps))

--- a/selphone/guarantees.py
+++ b/selphone/guarantees.py
@@ -1,0 +1,86 @@
+from typing import Generator
+
+
+# Selects potential candidates for place and manner of guaranteed
+def pickCandidates(curr_place: int, curr_manner: int, curr_laryng: int, curr_supr: int, sel_phonemes: list[tuple]) -> Generator:
+    for phoneme in sel_phonemes:
+        
+        # Laryngeal and nasalization guarantees
+        if curr_supr < (1 << 12):
+            manner = phoneme[1] & (7 << 8)
+            if manner == curr_manner:
+
+                place = phoneme[1] & 31
+                if place != curr_place:
+                    yield place + curr_laryng + manner + curr_supr
+
+        # Other suprasegmental guarantees
+        else:
+            place = phoneme[1] & 31
+            if place == curr_place:
+
+                manner = phoneme[1] & (7 << 8)
+                laryng = phoneme[1] & (7 << 5)
+
+                if not (manner == curr_manner and laryng == curr_laryng):    
+                    yield place + laryng + manner + curr_supr
+
+                
+"""
+Creates guarantees for Phoneme Selector based on selected phonemes. When a 
+non-tenuis phoneme of a given manner is selected, manageGuarantees finds
+all of places where tenuis phonemes of that manner are selected. Then, it 
+creates a list of all the phonemes at those places with the same manner and
+laryngeal features for guarantees.
+
+The same process occurs for nasals and other suprasegmentals, although the
+other suprasegmentals guarantees will apply to phonemes of the same place
+and different manners instead.
+"""
+def manageGuarantees(sel_phonemes: list[tuple]) -> list:
+    curr_phoneme = sel_phonemes[-1][1]
+
+    # Check if guarantees are applicable
+    curr_laryng = curr_phoneme & (7 << 5)
+    curr_nasal = curr_phoneme & (1 << 11)
+    curr_suprs = curr_phoneme & (7 << 13)
+
+    if not (curr_laryng or curr_nasal or curr_suprs):
+        return []
+    
+    curr_place = curr_phoneme % 32
+    curr_manner = curr_phoneme & (7 << 8)
+    candidates = []
+
+    if curr_laryng: # Laryngeal Feature Guarantees
+        candidates = list(set(pickCandidates(curr_place, curr_manner, curr_laryng, 0, sel_phonemes)))
+
+    if curr_nasal: # Nasalization Guarantees
+        candidates += list(set(pickCandidates(curr_place, curr_manner, curr_laryng, curr_nasal, sel_phonemes)))
+
+    if curr_suprs: # Other Suprasegmental Guarantees
+        candidates += list(set(pickCandidates(curr_place, curr_manner, curr_laryng, curr_suprs, sel_phonemes)))
+
+    # Filter out any phonemes that are already selected
+    for phoneme in sel_phonemes:
+        if phoneme[1] in candidates:
+            candidates.pop(candidates.index(phoneme[1]))
+
+    return candidates
+
+
+if __name__ == "__main__":
+    sps = [('p', 12), ('t', 10), ('k', 9), ('s', 1546), ('d', 138)]
+    print(manageGuarantees(sps))
+
+    sps = [('p', 12), ('t', 10), ('k', 9), ('s', 1546), ('b', 140), ('d', 138), ('g', 137)]
+    print(manageGuarantees(sps))
+
+    sps = [('p', 12), ('t', 10), ('k', 9), ('s', 1546), ('d', 138), ('ⁿt', 2058)]
+    print(manageGuarantees(sps))
+
+    sps = [('p', 12), ('t', 10), ('k', 9), ('s', 1546), ('d', 138), ('ⁿt', 2058), ('tʲ', 24586)]
+    print(manageGuarantees(sps))
+
+    sps = [('p', 12), ('t', 10), ('k', 9), ('s', 1546), ('d', 138), ('ⁿt', 2058), ('dʲ', 24714)]
+    print(manageGuarantees(sps))


### PR DESCRIPTION
- Had pharyngeal fricatives occur before pharyngeal plosives in permitted phonemes
- Delayed introduction of velar and uvular approximants in permitted phonemes
- Prevented non-lateral non-sibilant alveolar fricatives from being selected
- Updated dental/alveolar exceptions to scale in permissiveness for larger inventories
- Fixed extremely rare bug where a manner that should exist in permit_phones was not recognized in the constraint limiter
- Replaced old guarantees in Phoneme Selector (and featureSelector) with new guarantees function